### PR TITLE
propagate load options from the config to the gRPC handler

### DIFF
--- a/packages/handlers/grpc/src/index.ts
+++ b/packages/handlers/grpc/src/index.ts
@@ -545,7 +545,11 @@ ${rootJsonEntries
       const rootLogger = this.logger.child(name);
 
       rootLogger.debug(`Creating package definition from file descriptor set object`);
-      const packageDefinition = fromJSON(rootJson);
+      let options: LoadOptions;
+      if (typeof this.config.source === 'object') {
+        options = this.config.source.load;
+      }
+      const packageDefinition = fromJSON(rootJson, options);
 
       rootLogger.debug(`Creating service client for package definition`);
       const grpcObject = loadPackageDefinition(packageDefinition);


### PR DESCRIPTION
## Description
Propagate load options from the mesh config to the gRPC handler

Fixes #5277

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested manually

**Test Environment**:

- OS: macOS Ventura 13.2.1
-  Package versions
```
"@graphql-mesh/cli": "^0.82.23",
"@graphql-mesh/graphql": "^0.34.6",
```
- NodeJS: v18.14.1

## Checklist:

- [ ] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
